### PR TITLE
Adding a guard to check that ctx is of type 'bytes'

### DIFF
--- a/src/dilithium_py/ml_dsa/ml_dsa.py
+++ b/src/dilithium_py/ml_dsa/ml_dsa.py
@@ -388,7 +388,7 @@ class ML_DSA:
         Generates an ML-DSA signature following
         Algorithm 2 (FIPS 204)
         """
-        if isinstance(ctx, bytes):
+        if not isinstance(ctx, bytes):
             raise ValueError(
                 "ctx bytes must be of type 'bytes'."
             )


### PR DESCRIPTION
I accidentally passed a str into this and figured that a guard would be helpful.