### PR TITLE
Check if the signature is correct size

### DIFF
--- a/src/dilithium_py/ml_dsa/ml_dsa.py
+++ b/src/dilithium_py/ml_dsa/ml_dsa.py
@@ -152,6 +152,14 @@ class ML_DSA:
         t0_len = 416 * self.k
         return 2 * 32 + 64 + s1_len + s2_len + t0_len
 
+    def _sig_size(self) -> int:
+        if self.gamma_1 == 131072:
+            s_bytes = 18
+        else:
+            assert self.gamma_1 == 524288
+            s_bytes = 20
+        return self.c_tilde_bytes + self.l * 32 * s_bytes + self.omega + self.k
+
     def _unpack_sk(
         self, sk: bytes
     ) -> tuple[bytes, bytes, bytes, Vector, Vector, Vector]:
@@ -220,6 +228,8 @@ class ML_DSA:
         return self.M.vector(vector_coeffs)
 
     def _unpack_sig(self, sig: bytes) -> tuple[bytes, Vector, Vector]:
+        if len(sig) != self._sig_size():
+            raise ValueError("Incorrect signature size")
         c_tilde = sig[: self.c_tilde_bytes]
         z_bytes = sig[self.c_tilde_bytes : -(self.k + self.omega)]
         h_bytes = sig[-(self.k + self.omega) :]

--- a/tests/test_ml_dsa.py
+++ b/tests/test_ml_dsa.py
@@ -20,6 +20,10 @@ class TestMLDSA(unittest.TestCase):
             sig = ML_DSA.sign(sk, msg, ctx=ctx)
             check_verify = ML_DSA.verify(pk, msg, sig, ctx=ctx)
 
+            check_short_verify = ML_DSA.verify(pk, msg, sig[:-1], ctx=ctx)
+            check_long_verify = ML_DSA.verify(pk, msg, sig + b"\x00", ctx=ctx)
+            check_empty_verify = ML_DSA.verify(pk, msg, b"", ctx=ctx)
+
             # Sign with external_mu instead
             external_mu = ML_DSA.prehash_external_mu(pk, msg, ctx=ctx)
             sig_external_mu = ML_DSA.sign_external_mu(sk, external_mu)
@@ -39,6 +43,15 @@ class TestMLDSA(unittest.TestCase):
 
             # Check that signature works
             self.assertTrue(check_verify)
+
+            # Check that too short signature is rejected
+            self.assertFalse(check_short_verify)
+
+            # Check that too short signature is rejected
+            self.assertFalse(check_long_verify)
+
+            # Check that empty signature is rejected
+            self.assertFalse(check_empty_verify)
 
             # Check that external_mu also works
             self.assertTrue(check_external_mu)


### PR DESCRIPTION
Current code doesn't check if the signature is of the expected size for the ML-DSA parameters we are working with, with an empty signature that will cause the signing operation to raise an uncaught exception.

This fixes the issue