### PR TITLE
adds sha3-512 for hashml-dsa

### DIFF
--- a/src/dilithium_py/ml_dsa/hash_ml_dsa.py
+++ b/src/dilithium_py/ml_dsa/hash_ml_dsa.py
@@ -1,5 +1,5 @@
 from .ml_dsa import ML_DSA
-from hashlib import sha256, sha512, shake_128
+from hashlib import sha256, sha512, sha3_512, shake_128
 
 
 class HashML_DSA(ML_DSA):
@@ -16,6 +16,11 @@ class HashML_DSA(ML_DSA):
                 [0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x03]
             )
             ph_m = sha512(m).digest()
+        elif hash_name == "SHA3_512":
+            oid = bytes(
+                [0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x0a]
+            )
+            ph_m = sha3_512(m).digest()
         elif hash_name == "SHAKE128":
             oid = bytes(
                 [0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x0B]

--- a/tests/test_hash_ml_dsa.py
+++ b/tests/test_hash_ml_dsa.py
@@ -82,6 +82,16 @@ class TestHashMLDSA(unittest.TestCase):
     def test_hash_ml_dsa_87_sha256(self):
         self.generic_test_hash_ml_dsa(HASH_ML_DSA_87_WITH_SHA512, "SHA256")
 
+    # Test with SHA3-512
+    def test_hash_ml_dsa_44_sha3_512(self):
+        self.generic_test_hash_ml_dsa(HASH_ML_DSA_44_WITH_SHA512, "SHA3_512")
+
+    def test_hash_ml_dsa_65_sha3_512(self):
+        self.generic_test_hash_ml_dsa(HASH_ML_DSA_65_WITH_SHA512, "SHA3_512")
+
+    def test_hash_ml_dsa_87_sha3_512(self):
+        self.generic_test_hash_ml_dsa(HASH_ML_DSA_87_WITH_SHA512, "SHA3_512")
+
     # Test with SHAKE128
     def test_hash_ml_dsa_44_shake128(self):
         self.generic_test_hash_ml_dsa(HASH_ML_DSA_44_WITH_SHA512, "SHAKE128")


### PR DESCRIPTION
I made the minimal # of changes to add SHA3-512 for HashML-DSA, plus tests.

I was considering changing the HASH_ML_DSA_*_WITH_SHA512 object names because the _SHA512 can be overridden, making the name misleading, but that seems like a potentially breaking change if users expect those defaults. The alternative is to call the `_sign_with_pre_hash` method, but I always considered a leading `_` to indicate a private method that one should not call from the object directly.

Thanks!